### PR TITLE
Update PsAccountsService::getShopsTree to redirect to the PSX configuration page

### DIFF
--- a/src/Service/PsAccountsService.php
+++ b/src/Service/PsAccountsService.php
@@ -216,7 +216,7 @@ class PsAccountsService
                         true,
                         [],
                         [
-                            'configure' => $this->module->name,
+                            'configure' => $this->psxName,
                             'setShopContext' => 's-' . $shopId,
                         ]
                     ),


### PR DESCRIPTION
When we try to redirect from a multishop context to a single shop, we expect to stay on the same page or at least the same module. But at the moment we leave the current PSX to go to PS Accounts configuration page.

This triggers an error as there is no `getContent()` method in the PS Account module. This PR fixes the URLs stored in the shop tree.