### PR TITLE
Add shop context in accounts presented data

### DIFF
--- a/src/Presenter/PsAccountsPresenter.php
+++ b/src/Presenter/PsAccountsPresenter.php
@@ -72,6 +72,7 @@ class PsAccountsPresenter
                     'isSuperAdmin' => $this->psAccountsService->getContext()->employee->isSuperAdmin(),
                 ],
                 'currentShop' => $this->psAccountsService->getCurrentShop(),
+                'isShopContext' => $this->psAccountsService->isShopContext(),
                 'shops' => $this->psAccountsService->getShopsTree(),
                 'superAdminEmail' => $this->psAccountsService->getSuperAdminEmail(),
                 'ssoResendVerificationEmail' => $_ENV['SSO_RESEND_VERIFICATION_EMAIL'],


### PR DESCRIPTION
Relying on `currentShop` to know if the multishop selector should be displayed is a bad idea, as it is always defined. The Vue component needs to check if the current context is related to a single shop, which can't be found in the presenter for the moment.