### PR TITLE
Check class exist before loading one of its constants

### DIFF
--- a/src/Handler/ErrorHandler/ErrorHandler.php
+++ b/src/Handler/ErrorHandler/ErrorHandler.php
@@ -54,13 +54,18 @@ class ErrorHandler
     {
         $this->psAccountsService = new PsAccountsService();
 
+        $version = null;
+        if (class_exists('\Ps_accounts')) {
+            $version = \Ps_accounts::VERSION;
+        }
+
         $this->client = new Raven_Client(
             $_ENV['SENTRY_CREDENTIALS'],
             [
                 'level' => 'warning',
                 'tags' => [
                     'php_version' => phpversion(),
-                    'ps_accounts_version' => \Ps_accounts::VERSION,
+                    'ps_accounts_version' => $version,
                     'prestashop_version' => _PS_VERSION_,
                     'ps_accounts_is_enabled' => \Module::isEnabled('ps_accounts'),
                     'ps_accounts_is_installed' => \Module::isInstalled('ps_accounts'),


### PR DESCRIPTION
When the PS Accounts module is not installed on the shop, the error handler of the library can't get its version.

![image](https://user-images.githubusercontent.com/6768917/104609860-63c8c400-567b-11eb-8379-4a2c4b2e51ef.png)

This PR checks if the module exist first.